### PR TITLE
Add files via upload

### DIFF
--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -1458,7 +1458,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             cave=70
             fungus=60
             frozen=80
-            unwalkable=60
+            unwalkable=80
         [/defense]
         {DRAKEFLY_RESISTANCE}
     [/movetype]


### PR DESCRIPTION
Changes Flying drake units except Drake Glider to have 20% defense over unwalkable terrain requested in https://gna.org/bugs/index.php?23409. Drake Glider is kept at 40% to balance its low HP and high movement compared to other drake units.